### PR TITLE
Fix bug in string concatenation

### DIFF
--- a/96_Snapcast.pm
+++ b/96_Snapcast.pm
@@ -76,7 +76,7 @@ sub Snapcast_Initialize($) {
     $hash->{AttrFn}     = 'Snapcast_Attr';
     $hash->{ReadFn}     = 'Snapcast_Read';
     $hash->{AttrList} =
-          "streamnext:all,playing constraintDummy constraints volumeStepSize volumeStepSizeSmall volumeStepSizeThreshold"
+          "streamnext:all,playing constraintDummy constraints volumeStepSize volumeStepSizeSmall volumeStepSizeThreshold "
         . $readingFnAttributes;
 }
 


### PR DESCRIPTION
Just a space before the concatenation. Otherwise the attribute 'volumeStepSizeThreshold' would be misnamed. 